### PR TITLE
Support custom output formats on GetCaptions

### DIFF
--- a/captions.go
+++ b/captions.go
@@ -1,8 +1,11 @@
 package threeplay
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
+	"strconv"
 )
 
 // CaptionsFormat is supported output format for captions
@@ -29,11 +32,42 @@ const (
 	ADBE CaptionsFormat = "adbe"
 )
 
-// GetCaptions get captions by threeplay file ID with specific format
+// GetCaptionsByVideoID get captions by video ID with specific format
 // current supported formats are srt, dfxp, smi, stl, qt, qtxml, cptxml, adbe
-func (c *Client) GetCaptions(fileID uint, format CaptionsFormat) ([]byte, error) {
-	endpoint := fmt.Sprintf("https://%s/files/%d/captions.%s?apikey=%s",
-		threePlayStaticHost, fileID, format, c.apiKey)
+func (c *Client) GetCaptionsByVideoID(id string, format CaptionsFormat) ([]byte, error) {
+	return c.GetCaptions(GetCaptionsOptions{
+		VideoID: id,
+		Format:  format,
+	})
+}
+
+// GetCaptionsOptions represents the set of options that can be provided when
+// obtaining a captions file.
+type GetCaptionsOptions struct {
+	// FileID should be specified to download the captions file by its ID.
+	// This option is mutually exclusive with VideoID.
+	FileID uint
+
+	// VideoID should be specified to download the captions file specifying
+	// the video ID. This option is mutually exclusive with FileID.
+	VideoID string
+
+	// Format specifies the standard format that should be used. Please
+	// refer to the constants exported by this package to see the available
+	// formats. This option is mutually exclusive with Outputformat.
+	Format CaptionsFormat
+
+	// OutputFormat specifies the custom format that should be used.
+	// This option is mutually exclusive with Format.
+	OutputFormat string
+}
+
+// GetCaptions retrieves caption files according to the given options.
+func (c *Client) GetCaptions(opts GetCaptionsOptions) ([]byte, error) {
+	endpoint, err := c.getEndpoint(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	response, err := c.httpClient.Get(endpoint)
 	if err != nil {
@@ -51,23 +85,32 @@ func (c *Client) GetCaptions(fileID uint, format CaptionsFormat) ([]byte, error)
 	return responseData, nil
 }
 
-// GetCaptionsByVideoID get captions by video ID with specific format
-// current supported formats are srt, dfxp, smi, stl, qt, qtxml, cptxml, adbe
-func (c *Client) GetCaptionsByVideoID(id string, format CaptionsFormat) ([]byte, error) {
-	endpoint := fmt.Sprintf("https://%s/files/%s/captions.%s?apikey=%s&usevideoid=1",
-		threePlayStaticHost, id, format, c.apiKey)
+func (c *Client) getEndpoint(opts GetCaptionsOptions) (string, error) {
+	var (
+		id   string
+		path string
+	)
+	params := url.Values{}
+	params.Set("apikey", c.apiKey)
 
-	response, err := c.httpClient.Get(endpoint)
-	if err != nil {
-		return nil, err
+	switch {
+	case opts.FileID != 0:
+		id = strconv.FormatUint(uint64(opts.FileID), 10)
+	case opts.VideoID != "":
+		params.Set("usevideoid", "1")
+		id = opts.VideoID
+	default:
+		return "", errors.New("cannot determine the endpoint: missing file ID and the video ID")
 	}
 
-	responseData, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
+	switch {
+	case opts.OutputFormat != "":
+		path = fmt.Sprintf("/files/%s/output_formats/%s", id, opts.OutputFormat)
+	case opts.Format != "":
+		path = fmt.Sprintf("/files/%s/captions.%s", id, opts.Format)
+	default:
+		return "", errors.New("cannot determine the endpoint: missing format and custom output format")
 	}
-	if err := checkForAPIError(responseData); err != nil {
-		return nil, err
-	}
-	return responseData, nil
+
+	return fmt.Sprintf("https://%s%s?%s", threePlayStaticHost, path, params.Encode()), nil
 }

--- a/captions_test.go
+++ b/captions_test.go
@@ -9,19 +9,108 @@ import (
 )
 
 func TestGetCaptions(t *testing.T) {
-	assert := assert.New(t)
-	defer gock.Off()
+	var tests = []struct {
+		name   string
+		opts   threeplay.GetCaptionsOptions
+		path   string
+		params map[string]string
+	}{
+		{
+			"with file id and standard format",
+			threeplay.GetCaptionsOptions{
+				FileID: 123456,
+				Format: threeplay.SRT,
+			},
+			"/files/123456/captions.srt",
+			map[string]string{"apikey": "api-key"},
+		},
+		{
+			"with file id and custom format",
+			threeplay.GetCaptionsOptions{
+				FileID:       123456,
+				OutputFormat: "42.srt",
+			},
+			"/files/123456/output_formats/42.srt",
+			map[string]string{"apikey": "api-key"},
+		},
+		{
+			"with video id and standard format",
+			threeplay.GetCaptionsOptions{
+				VideoID: "vid-123",
+				Format:  threeplay.SRT,
+			},
+			"/files/vid-123/captions.srt",
+			map[string]string{"apikey": "api-key", "usevideoid": "1"},
+		},
+		{
+			"with video id and custom format",
+			threeplay.GetCaptionsOptions{
+				VideoID:      "vid-123",
+				OutputFormat: "42.vtt",
+			},
+			"/files/vid-123/output_formats/42.vtt",
+			map[string]string{"apikey": "api-key", "usevideoid": "1"},
+		},
+		{
+			"with all fields - should prefer custom format && file id",
+			threeplay.GetCaptionsOptions{
+				FileID:       123456,
+				VideoID:      "vid-123",
+				Format:       threeplay.WebVTT,
+				OutputFormat: "42.srt",
+			},
+			"/files/123456/output_formats/42.srt",
+			map[string]string{"apikey": "api-key"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			defer gock.Off()
 
-	gock.New("https://static.3playmedia.com").
-		Get("/files/123456/captions.srt").
-		MatchParam("apikey", "api-key").
-		Reply(200).
-		File("./fixtures/captions.srt")
+			gock.New("https://static.3playmedia.com").
+				Get(test.path).
+				MatchParams(test.params).
+				Reply(200).
+				File("./fixtures/captions.srt")
 
-	client := threeplay.NewClient("api-key", "secret-key")
-	result, err := client.GetCaptions(123456, threeplay.SRT)
-	assert.NotNil(result)
-	assert.Nil(err)
+			client := threeplay.NewClient("api-key", "secret-key")
+			result, err := client.GetCaptions(test.opts)
+			assert.NotNil(result)
+			assert.Nil(err)
+		})
+	}
+}
+
+func TestGetCaptionsApiInvalidOptions(t *testing.T) {
+	var tests = []struct {
+		name string
+		opts threeplay.GetCaptionsOptions
+	}{
+		{
+			"missing format",
+			threeplay.GetCaptionsOptions{
+				FileID:  10,
+				VideoID: "vid-123",
+			},
+		},
+		{
+			"missing id",
+			threeplay.GetCaptionsOptions{
+				Format:       threeplay.SRT,
+				OutputFormat: "42.srt",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			client := threeplay.NewClient("api-key", "secret-key")
+			result, err := client.GetCaptions(test.opts)
+			assert.Nil(result)
+			assert.NotNil(err)
+		})
+	}
 }
 
 func TestGetCaptionsApiError(t *testing.T) {
@@ -35,7 +124,10 @@ func TestGetCaptionsApiError(t *testing.T) {
 		File("./fixtures/error.json")
 
 	client := threeplay.NewClient("api-key", "secret-key")
-	result, err := client.GetCaptions(123456, threeplay.SRT)
+	result, err := client.GetCaptions(threeplay.GetCaptionsOptions{
+		FileID: 123456,
+		Format: threeplay.SRT,
+	})
 	assert.Nil(result)
 	assert.NotNil(err)
 	assert.Equal(threeplay.ErrUnauthorized.Error(), err.Error())


### PR DESCRIPTION
3play API is kinda weird in this situation, so the paths for custom and
standard formats are different.

The custom format is in the form ``<id>.<extension>``. The included test
has an example.