### PR TITLE
V3: Adds optional way to change api keys with every call

### DIFF
--- a/v3api/client.go
+++ b/v3api/client.go
@@ -1,4 +1,4 @@
-package v3api // import "github.com/NYTimes/threeplay
+package v3api // import "github.com/NYTimes/threeplay/v3api"
 
 import (
 	"encoding/json"

--- a/v3api/file.go
+++ b/v3api/file.go
@@ -23,10 +23,11 @@ type FileObjectRepresentation struct {
 
 // UploadFileFromURL uploads a file to threeplay using the file's URL and
 // returns the file ID.
-func (c *Client) UploadFileFromURL(options url.Values) (int, error) {
+func (c *Client) UploadFileFromURL(options url.Values, callParams CallParams) (int, error) {
+	apiKey := c.setAPIKey(callParams.APIKey)
 	apiURL := c.createURL("/files")
 	data := url.Values{}
-	data.Set("api_key", c.apiKey)
+	data.Set("api_key", apiKey)
 	for key, val := range options {
 		data[key] = val
 	}

--- a/v3api/file_test.go
+++ b/v3api/file_test.go
@@ -25,7 +25,30 @@ func TestUploadFile(t *testing.T) {
 	data.Set("source_id", "https://somewhere.com/72397_1_08macron-speech_wg_360p.mp4")
 	data.Set("language_id", "1")
 
-	fileID, err := client.UploadFileFromURL(data)
+	callParams := v3api.CallParams{APIKey: ""}
+	fileID, err := client.UploadFileFromURL(data, callParams)
+	assert.Equal(3628518, fileID)
+	assert.Nil(err)
+}
+
+func TestUploadFileCustomAPI(t *testing.T) {
+	assert := assert.New(t)
+
+	defer gock.Off()
+	gock.New("https://api.3playmedia.com").
+		Post("/v3/files").
+		MatchType("url").
+		BodyString("api_key=custom-key&language_id=1&source_id=https%3A%2F%2Fsomewhere.com%2F72397_1_08macron-speech_wg_360p.mp4").
+		Reply(200).
+		File("../fixtures/v3_file_upload_200.json")
+
+	client := v3api.NewClient("api-key")
+	data := url.Values{}
+	data.Set("source_id", "https://somewhere.com/72397_1_08macron-speech_wg_360p.mp4")
+	data.Set("language_id", "1")
+
+	callParams := v3api.CallParams{APIKey: "custom-key"}
+	fileID, err := client.UploadFileFromURL(data, callParams)
 	assert.Equal(3628518, fileID)
 	assert.Nil(err)
 }
@@ -46,7 +69,8 @@ func TestUploadFileError(t *testing.T) {
 	data.Set("language_id", "1")
 	data.Set("bad_param", "so-bad")
 
-	fileID, err := client.UploadFileFromURL(data)
+	callParams := v3api.CallParams{APIKey: ""}
+	fileID, err := client.UploadFileFromURL(data, callParams)
 	assert.Equal(0, fileID)
 	assert.NotNil(err)
 	assert.Equal("400: parameter_error-Unrecognized parameters supplied: 'bad_param'", err.Error())

--- a/v3api/transcripts_test.go
+++ b/v3api/transcripts_test.go
@@ -21,7 +21,29 @@ func TestOrderTranscript(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	transcriptData, err := client.OrderTranscript("3628518", "", "asr")
+	callParams := v3api.CallParams{APIKey: ""}
+	transcriptData, err := client.OrderTranscript("3628518", "", "asr", callParams)
+	assert.Nil(err)
+	assert.NotNil(transcriptData)
+	assert.Equal("pending", transcriptData.Status)
+	assert.Equal("AsrTranscript", transcriptData.Type)
+}
+
+func TestOrderTranscriptCustomAPIKey(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.Off()
+
+	gock.New("https://api.3playmedia.com").
+		Post("/v3/transcripts/order/asr").
+		MatchType("url").
+		BodyString("api_key=custom-key&media_file_id=3628518").
+		Reply(200).
+		File("../fixtures/v3_transcript_order_200.json")
+
+	client := v3api.NewClient("api-key")
+
+	callParams := v3api.CallParams{APIKey: "custom-key"}
+	transcriptData, err := client.OrderTranscript("3628518", "", "asr", callParams)
 	assert.Nil(err)
 	assert.NotNil(transcriptData)
 	assert.Equal("pending", transcriptData.Status)
@@ -41,7 +63,8 @@ func TestOrderTranscriptError(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	transcriptData, err := client.OrderTranscript("123456", "", "asr")
+	callParams := v3api.CallParams{APIKey: ""}
+	transcriptData, err := client.OrderTranscript("123456", "", "asr", callParams)
 	assert.Empty(transcriptData)
 	assert.NotNil(err)
 	assert.Equal("404: not_found_error-Not found", err.Error())
@@ -59,7 +82,8 @@ func TestTranscriptInfo(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	transcriptData, err := client.GetTranscriptInfo("3633088")
+	callParams := v3api.CallParams{APIKey: ""}
+	transcriptData, err := client.GetTranscriptInfo("3633088", callParams)
 	assert.Nil(err)
 	assert.NotNil(transcriptData)
 	assert.Equal("complete", transcriptData.Status)
@@ -78,7 +102,8 @@ func TestTranscriptInfoError(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	transcriptData, err := client.GetTranscriptInfo("123")
+	callParams := v3api.CallParams{APIKey: ""}
+	transcriptData, err := client.GetTranscriptInfo("123", callParams)
 	assert.Empty(transcriptData)
 	assert.NotNil(err)
 	assert.Equal("500: standard_error-Internal server error", err.Error())
@@ -97,7 +122,8 @@ func TestTranscriptText(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	transcript, err := client.GetTranscriptText("3633088", "", "vtt")
+	callParams := v3api.CallParams{APIKey: ""}
+	transcript, err := client.GetTranscriptText("3633088", "", "vtt", callParams)
 	assert.Nil(err)
 	assert.NotEmpty(transcript)
 }
@@ -116,7 +142,8 @@ func TestTranscriptTextError(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	transcript, err := client.GetTranscriptText("9846", "", "vtt")
+	callParams := v3api.CallParams{APIKey: ""}
+	transcript, err := client.GetTranscriptText("9846", "", "vtt", callParams)
 	assert.Empty(transcript)
 	assert.NotNil(err)
 	assert.Equal("500: standard_error-Internal server error", err.Error())
@@ -135,7 +162,8 @@ func TestTranscriptCancel(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	err := client.CancelTranscript("8794567")
+	callParams := v3api.CallParams{APIKey: ""}
+	err := client.CancelTranscript("8794567", callParams)
 	assert.Nil(err)
 }
 
@@ -152,7 +180,8 @@ func TestTranscriptCancelError(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	err := client.CancelTranscript("843759")
+	callParams := v3api.CallParams{APIKey: ""}
+	err := client.CancelTranscript("843759", callParams)
 	assert.NotNil(err)
 	assert.Equal("403: forbidden_error-You cannot cancel this transcript at this time.", err.Error())
 }
@@ -170,7 +199,8 @@ func TestTranscriptEditingLink(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	link, err := client.GetEditingLink("3633088", 2)
+	callParams := v3api.CallParams{APIKey: ""}
+	link, err := client.GetEditingLink("3633088", 2, callParams)
 	assert.Nil(err)
 	assert.Equal("http://external.3playmedia.com/transcripts/3633088/edit?exp_key=key", link)
 }
@@ -188,7 +218,8 @@ func TestTranscriptEditingLinkError(t *testing.T) {
 
 	client := v3api.NewClient("api-key")
 
-	link, err := client.GetEditingLink("bad-id", 2)
+	callParams := v3api.CallParams{APIKey: ""}
+	link, err := client.GetEditingLink("bad-id", 2, callParams)
 	assert.Empty(link)
 	assert.NotNil(err)
 	assert.Equal("404: not_found_error-Not found", err.Error())


### PR DESCRIPTION
In order to be able to send jobs to different projects, each requiring a different API key, we're adding the option to specify an `APIKey` field in a `callParams` structure. A structure was chosen in case we'd want to override other call params in the future.