### PR TITLE
ignore lint errors recently added to golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - go mod download
   - curl https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINDIR=$GOPATH/bin sh
 script:
-  - golangci-lint run --enable-all -D errcheck -D lll -D dupl -D gochecknoglobals --deadline 5m
+  - golangci-lint run --enable-all -D errcheck -D lll -D dupl -D gochecknoglobals -D funlen -D wsl --deadline 5m
   - go test -v -coverprofile=coverage.txt -covermode=atomic ./...
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/v2api/file_test.go
+++ b/v2api/file_test.go
@@ -189,7 +189,6 @@ func TestUpdateFileError(t *testing.T) {
 
 	assert.NotNil(err)
 	assert.Equal(v2api.ErrUnauthorized.Error(), err.Error())
-
 }
 
 func TestUploadFileFromURL(t *testing.T) {

--- a/v2api/tag.go
+++ b/v2api/tag.go
@@ -10,7 +10,6 @@ import (
 
 // GetTags gets the list of tags of a file
 func (c *Client) GetTags(fileID uint) ([]string, error) {
-
 	endpoint := fmt.Sprintf("https://%s/files/%d/tags?apikey=%s", types.ThreePlayHost, fileID, c.apiKey)
 	response, err := c.httpClient.Get(endpoint)
 	if err != nil {

--- a/v2api/transcripts.go
+++ b/v2api/transcripts.go
@@ -72,7 +72,6 @@ func (c *Client) GetTranscriptWithFormat(id uint, format TranscriptFormat) ([]by
 
 // GetTranscriptByVideoID get json transcript by video ID
 func (c *Client) GetTranscriptByVideoID(videoID string) (*Transcript, error) {
-
 	response, err := c.GetTranscriptByVideoIDWithFormat(videoID, JSON)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This should fix the travisci build. We should consider moving go `golint` and `go vet` in the future.