### PR TITLE
pin version of golangci-lint so build stays consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.x
 install:
   - go mod download
-  - curl https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINDIR=$GOPATH/bin sh
+  - curl https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINDIR=$GOPATH/bin sh -s v1.21.0
 script:
   - golangci-lint run --enable-all -D errcheck -D lll -D dupl -D gochecknoglobals -D funlen -D wsl --deadline 5m
   - go test -v -coverprofile=coverage.txt -covermode=atomic ./...


### PR DESCRIPTION
The build has been failing for a while due to the new `gomnd` linter. This PR makes is so something like that shouldn't happen in the future.